### PR TITLE
Add move model ability. 

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-ZOXEL_VERSION = "0.4.8 (14th January 2014)"
+ZOXEL_VERSION = "0.5.0 (20th January 2014)"

--- a/src/plugins/tool_colourpick.py
+++ b/src/plugins/tool_colourpick.py
@@ -32,9 +32,9 @@ class ColourPickTool(Tool):
         self.api.register_tool(self)
 
     # Grab the colour of the selected voxel
-    def on_activate(self, target, mouse_position):
+    def on_mouse_click(self, target):
         # If we have a voxel at the target, colour it
-        voxel = target.voxels.get(target.x, target.y, target.z)
+        voxel = target.voxels.get(target.world_x, target.world_y, target.world_z)
         if voxel:
             self.api.set_palette_colour(voxel)
 

--- a/src/plugins/tool_drag.py
+++ b/src/plugins/tool_drag.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from PySide import QtGui
-from tool import Tool
+from tool import Tool, EventData, MouseButtons, KeyModifiers, Face
 from plugin_api import register_plugin
 
 class DragTool(Tool):
@@ -32,13 +32,13 @@ class DragTool(Tool):
         self.api.register_tool(self)
 
     # Colour the targeted voxel
-    def on_activate(self, target, mouse_position):
-        self._mouse = mouse_position
+    def on_drag_start(self, target):
+        self._mouse = (target.mouse_x, target.mouse_y)
 
     # Drag the model in voxel space
-    def on_drag(self, target, mouse_position):
-            dx = mouse_position[0] - self._mouse[0]
-            dy = mouse_position[1] - self._mouse[1]
+    def on_drag(self, target):
+            dx = target.mouse_x - self._mouse[0]
+            dy = target.mouse_y - self._mouse[1]
             # Work out some sort of vague translation between screen and voxels
             sx = self.api.mainwindow.width() / target.voxels.width
             sy = self.api.mainwindow.height() / target.voxels.height
@@ -81,7 +81,7 @@ class DragTool(Tool):
                     tz = -1
             
             if ty != 0 or tx != 0 or tz != 0:
-                self._mouse = mouse_position
+                self._mouse = (target.mouse_x, target.mouse_y)
             
             target.voxels.translate(tx, ty, tz)
             

--- a/src/plugins/tool_erase.py
+++ b/src/plugins/tool_erase.py
@@ -32,7 +32,7 @@ class EraseTool(Tool):
         self.api.register_tool(self)
 
     # Clear the targeted voxel
-    def on_activate(self, target, mouse_position):
-        target.voxels.set(target.x, target.y, target.z, 0)
+    def on_mouse_click(self, target):
+        target.voxels.set(target.world_x, target.world_y, target.world_z, 0)
 
 register_plugin(EraseTool, "Erasing Tool", "1.0")

--- a/src/plugins/tool_fill.py
+++ b/src/plugins/tool_fill.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from PySide import QtGui
-from tool import Tool
+from tool import Tool, EventData, MouseButtons, KeyModifiers, Face
 from plugin_api import register_plugin
 
 class FillTool(Tool):
@@ -32,9 +32,9 @@ class FillTool(Tool):
         self.api.register_tool(self)
 
     # Fill all connected voxels of the same colour with a new colour
-    def on_activate(self, target, mouse_position):
+    def on_mouse_click(self, target):
         # We need to have a selected voxel
-        voxel = target.voxels.get(target.x, target.y, target.z)
+        voxel = target.voxels.get(target.world_x, target.world_y, target.world_z)
         if not voxel:
             return
         # Grab the target colour
@@ -46,7 +46,7 @@ class FillTool(Tool):
             return
         # Initialise our search list
         search = []
-        search.append((target.x, target.y, target.z))
+        search.append((target.world_x, target.world_y, target.world_z))
         # Keep iterating over the search list until no more to do
         while len(search):
             x,y,z = search.pop()

--- a/src/plugins/tool_paint.py
+++ b/src/plugins/tool_paint.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from PySide import QtGui
-from tool import Tool
+from tool import Tool, EventData, MouseButtons, KeyModifiers, Face
 from plugin_api import register_plugin
 
 class PaintingTool(Tool):
@@ -32,17 +32,14 @@ class PaintingTool(Tool):
         self.api.register_tool(self)
 
     # Colour the targeted voxel
-    def on_activate(self, target, mouse_position):
+    def on_mouse_click(self, data):
         # If we have a voxel at the target, colour it
-        voxel = target.voxels.get(target.x, target.y, target.z)
+        voxel = data.voxels.get(data.world_x, data.world_y, data.world_z)
         if voxel:
-            target.voxels.set(target.x, target.y, target.z, self.colour)
+            data.voxels.set(data.world_x, data.world_y, data.world_z, self.colour)
 
     # Colour when dragging also
-    def on_drag(self, target, mouse_position):
-        # If we have a voxel at the target, colour it
-        voxel = target.voxels.get(target.x, target.y, target.z)
-        if voxel:
-            target.voxels.set(target.x, target.y, target.z, self.colour)
+    def on_drag(self, data):
+        self.on_mouse_click(data)
 
 register_plugin(PaintingTool, "Painting Tool", "1.0")

--- a/src/tool.py
+++ b/src/tool.py
@@ -17,6 +17,17 @@
 
 from PySide import QtGui
 
+# Enumeration type
+def enum(*sequential, **named):
+    enums = dict(zip(sequential, range(len(sequential))), **named)
+    return type('Enum', (), enums)
+
+# Mouse buttons
+MouseButtons = enum('LEFT', 'MIDDLE', 'RIGHT')
+
+# Keyboard modifiers
+KeyModifiers = enum('CTRL', 'SHIFT', 'ALT')
+
 class Face(object):
     FRONT = 0   # z-
     TOP = 1     # y+
@@ -28,43 +39,94 @@ class Face(object):
     FACES_PLANE_X = [LEFT, RIGHT]
     FACES_PLANE_Y = [TOP, BOTTOM]
     FACES_PLANE_Z = [BACK, FRONT]
-    # Defining the faces for each plane used in the collision detection algorithm, where the Y plane is collidable (But X and Z are not).
+    # Defining the faces for each plane used in the collision detection 
+    # algorithm, where the Y plane is collidable (But X and Z are not).
     COLLIDABLE_FACES_PLANE_X = FACES_PLANE_X
     COLLIDABLE_FACES_PLANE_Y = FACES_PLANE_Y + [None]
     COLLIDABLE_FACES_PLANE_Z = FACES_PLANE_Z
 
-
-class Target(object):
+class EventData(object):
 
     @property
     def face(self):
         return self._face
+    @face.setter
+    def face(self, value):
+        self._face = value
 
     @property
-    def x(self):
-        return self._x
+    def world_x(self):
+        return self._world_x
+    @world_x.setter
+    def world_x(self, value):
+        self._world_x = value
 
     @property
-    def y(self):
-        return self._y
+    def world_y(self):
+        return self._world_y
+    @world_y.setter
+    def world_y(self, value):
+        self._world_y = value
 
     @property
-    def z(self):
-        return self._z
+    def world_z(self):
+        return self._world_z
+    @world_z.setter
+    def world_z(self, value):
+        self._world_z = value
 
     @property
     def voxels(self):
         return self._voxels
+    @voxels.setter
+    def voxels(self, value):
+        self._voxels = value
+
+    @property
+    def mouse_x(self):
+        return self._mouse_x
+    @mouse_x.setter
+    def mouse_x(self, value):
+        self._mouse_x = value
+
+    @property
+    def mouse_y(self):
+        return self._mouse_y
+    @mouse_y.setter
+    def mouse_y(self, value):
+        self._mouse_y = value
+
+    @property
+    def mouse_button(self):
+        return self._mouse_button
+    @mouse_button.setter
+    def mouse_button(self, value):
+        self._mouse_button = value
+
+    @property
+    def key_modifiers(self):
+        return self._key_modifiers
+    @key_modifiers.setter
+    def key_modifiers(self, value):
+        self._key_modifiers = value
 
     def __repr__(self):
-        return 'Target(face=%s,x=%d,y=%d,z=%d)' % (self._face, self._x, self._y, self._z)
+        return ('EventData(face={0},world_x={1},world_y={2},world_z={3},'
+                'mouse_x={4},mouse_y={5},mouse_button={6},key_modifiers={7})'.format( 
+                self._face, self._world_x, self._world_y, self._world_z,
+                   self._mouse_x, self._mouse_y, self._mouse_button, 
+                   self._key_modifiers))
 
-    def __init__(self, voxels, x, y, z, face = None):
-        self._face = face
-        self._x = x
-        self._y = y
-        self._z = z
-        self._voxels = voxels
+    def __init__(self):
+        self._face = None
+        self._world_x = 0
+        self._world_y = 0
+        self._world_z = 0
+        self._mouse_x = 0
+        self._mouse_y = 0
+        self._mouse_button = None
+        self._key_modifiers = None
+        self._voxels = None
 
     def __eq__(self, other):
         return ( (self._x == other._x) and
@@ -78,9 +140,9 @@ class Target(object):
     def get_neighbour(self):
         if self.face is None:
             return None
-        x = self.x
-        y = self.y
-        z = self.z
+        x = self._world_x
+        y = self._world_y
+        z = self._world_z
         if self.face == Face.TOP:
             y += 1
         elif self.face == Face.BOTTOM:
@@ -110,22 +172,27 @@ class Tool(object):
             "A Tool", None)
         self.action.setStatusTip("Unknown Tool")
 
-    # Called when the left mouse button is pressed
-    def on_activate(self, target, mouse_position):
+    # Mouse click - a mouse button has been pressed and released
+    def on_mouse_click(self, data):
+        pass
+    
+    # A mouse drag has started
+    def on_drag_start(self, data):
+        pass
+    
+    # Mouse is dragging
+    def on_drag(self, data):
+        pass
+    
+    # A mouse drag ended
+    def on_drag_end(self, data):
         pass
 
-    # Called when the right mouse button is pressed
-    def on_activate_alt(self, target, mouse_position):
+    # Signal to the tool to cancel whatever it's doing and reset it's state
+    # back to default
+    def on_cancel(self, data):
         pass
-
-    # Called when the left mouse button is held down and dragged
-    def on_drag(self, target, mouse_position):
-        pass
-
-    # Called when the left mouse button is released
-    def on_deactivate(self, target):
-        pass
-
+    
     # Should return the action for the tool
     def get_action(self):
         return self.action


### PR DESCRIPTION
Add the ability to move model.
The keyboard shortcuts could be:
ctrl/⌘ + UP_ARROW / DOWN_ARROW / LEFT_ARROW / RIGHT_ARROW for x and z axes and, alt + ctrl/⌘ + UP_ARROW / DOWN_ARROW for y axes.

The code could look like this (for the move method:

```
# Move voxels  on axis
def move_on_axis(self, axis, dir):#dir = +1 or -1
    # Reset undo buffer
    self._undo.clear()

    for i, frame in enumerate(self._frames):

        # Create new temporary data structure
        data = [[[0 for _ in xrange(self.depth)]
            for _ in xrange(self.height)]
                for _ in xrange(self.width)]

        # Copy data over at new location
        for tx in xrange(0, self.width):
            for ty in xrange(0, self.height):
                for tz in xrange(0, self.depth):
                    if axis == self.Y_AXIS:
                        dx = tx
                        dy = (ty)+1*dir
                        dz = tz
                    elif axis == self.X_AXIS:
                        dx = (tx)+1*dir
                        dy = ty
                        dz = tz
                    elif axis == self.Z_AXIS:
                        dx = tx
                        dy = ty
                        dz = (tz)+1*dir
                    data[dx][dy][dz] = frame[tx][ty][tz]
        self._frames[i] = data

    self._data = self._frames[self._current_frame]
    # Rebuild our cache
    self._cache_rebuild()
    self.changed = True
```
